### PR TITLE
feat(waf): add OWASP Top 10 rules and fix URL-encoded evasion bypass

### DIFF
--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -148,7 +148,7 @@ func seedDefaults(db *sql.DB) error {
 			{"Block Admin", `Path startsWith "/admin"`, 10},
 			
 			// OWASP A03:2021 - Injection (SQLi)
-			{"Block SQL Injection (Path)", `Path matches "(?i)(union|select|insert|delete|update|drop|--|;).*$"`, 20},
+			{"Block SQL Injection (Path)", `Path matches ".*(?i)(union\\s+select|waitfor\\s+delay|1=1|--|;).*$"`, 20},
 			{"Block SQL Injection (Query)", `RawQuery matches "(?i)(union\\s+select|waitfor\\s+delay|1=1|--|;)"`, 20},
 			
 			// OWASP A03:2021 - Injection (XSS)
@@ -157,6 +157,8 @@ func seedDefaults(db *sql.DB) error {
 			
 			// OWASP A01:2021 - Broken Access Control (Path Traversal)
 			{"Block Path Traversal", `Path matches "(?:\\.\\./|\\.\\.\\\\)"`, 20},
+			{"Block Path Traversal (Path)", `Path matches ".*(?i)(%2e%2e%2f|%2e%2e\\%5c).*$"`, 20},
+			{"Block Path Traversal (Query)", `RawQuery matches ".*(?i)(%2e%2e%2f|%2e%2e%5c).*$"`, 20},
 			
 			// OWASP A10:2021 - Server-Side Request Forgery (SSRF)
 			{"Block SSRF Metadata & Localhost", `RawQuery matches "(?i)(169\\.254\\.169\\.254|127\\.0\\.0\\.1|localhost)"`, 20},

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -138,15 +138,28 @@ func seedDefaults(db *sql.DB) error {
 
 	err = db.QueryRow("SELECT COUNT(*) FROM waf_rules").Scan(&count)
 	if err == nil && count == 0 {
+		// --- ENHANCED OWASP TOP 10 WAF RULES ---
 		rules := []struct {
 			Name       string
 			Expression string
 			Priority   int
 		}{
+			// General Admin Block
 			{"Block Admin", `Path startsWith "/admin"`, 10},
-			{"Block SQL Injection", `Path matches "(?i)(union|select|insert|delete|update|drop).*"`, 20},
-			{"Block XSS", `Path matches "(?i)<script>"`, 20},
-			{"Block Path Traversal", `Path matches "\\.\\./"`, 20},
+			
+			// OWASP A03:2021 - Injection (SQLi)
+			{"Block SQL Injection (Path)", `Path matches "(?i)(union|select|insert|delete|update|drop|--|;).*$"`, 20},
+			{"Block SQL Injection (Query)", `RawQuery matches "(?i)(union\\s+select|waitfor\\s+delay|1=1|--|;)"`, 20},
+			
+			// OWASP A03:2021 - Injection (XSS)
+			{"Block XSS (Path)", `Path matches "(?i)(<script>|javascript:|onerror=)"`, 20},
+			{"Block XSS (Query)", `RawQuery matches "(?i)(<script>|javascript:|onerror=)"`, 20},
+			
+			// OWASP A01:2021 - Broken Access Control (Path Traversal)
+			{"Block Path Traversal", `Path matches "(?:\\.\\./|\\.\\.\\\\)"`, 20},
+			
+			// OWASP A10:2021 - Server-Side Request Forgery (SSRF)
+			{"Block SSRF Metadata & Localhost", `RawQuery matches "(?i)(169\\.254\\.169\\.254|127\\.0\\.0\\.1|localhost)"`, 20},
 		}
 
 		for _, rule := range rules {
@@ -155,7 +168,7 @@ func seedDefaults(db *sql.DB) error {
 			if err != nil {
 				log.Error().Err(err).Str("rule", rule.Name).Msg("Failed to insert WAF rule")
 			} else {
-				log.Info().Str("rule", rule.Name).Msg("Inserted default WAF rule")
+				log.Info().Str("rule", rule.Name).Msg("Inserted WAF rule")
 			}
 		}
 	}

--- a/internal/waf/waf.go
+++ b/internal/waf/waf.go
@@ -34,11 +34,11 @@ func Check(db *sql.DB, r *http.Request, debugLogs bool) (bool, string) {
 		ip = r.RemoteAddr
 	}
 
-	// SECURITY FIX: URL-decode the query string before feeding it to the WAF engine
-	// This prevents attackers from bypassing regex rules using %20 or +
+	/// SECURITY FIX: URL-decode the query string before feeding it to the WAF engine
 	decodedQuery, err := url.QueryUnescape(r.URL.RawQuery)
 	if err != nil {
-		decodedQuery = r.URL.RawQuery // Fallback to raw if decoding fails
+		log.Warn().Err(err).Msg("Blocked request due to malformed URL encoding")
+		return true, "Block Malformed Encoding"
 	}
 
 	env := WAFContext{

--- a/internal/waf/waf.go
+++ b/internal/waf/waf.go
@@ -4,17 +4,21 @@ import (
 	"database/sql"
 	"net"
 	"net/http"
+	"net/url"
 	"strings"
 
 	"github.com/expr-lang/expr"
 	"github.com/rs/zerolog/log"
 )
 
+// WAFContext defines the variables exposed to the rule engine.
 type WAFContext struct {
-	IP      string
-	Method  string
-	Path    string
-	Headers map[string][]string
+	IP       string
+	Method   string
+	Path     string
+	Query    map[string][]string
+	RawQuery string
+	Headers  map[string][]string
 }
 
 func Check(db *sql.DB, r *http.Request, debugLogs bool) (bool, string) {
@@ -30,11 +34,20 @@ func Check(db *sql.DB, r *http.Request, debugLogs bool) (bool, string) {
 		ip = r.RemoteAddr
 	}
 
+	// SECURITY FIX: URL-decode the query string before feeding it to the WAF engine
+	// This prevents attackers from bypassing regex rules using %20 or +
+	decodedQuery, err := url.QueryUnescape(r.URL.RawQuery)
+	if err != nil {
+		decodedQuery = r.URL.RawQuery // Fallback to raw if decoding fails
+	}
+
 	env := WAFContext{
-		IP:      ip,
-		Method:  r.Method,
-		Path:    r.URL.Path,
-		Headers: r.Header,
+		IP:       ip,
+		Method:   r.Method,
+		Path:     r.URL.Path,
+		Query:    r.URL.Query(),
+		RawQuery: decodedQuery, // Now feeding the clean, decoded string
+		Headers:  r.Header,
 	}
 
 	for rows.Next() {

--- a/internal/waf/waf_test.go
+++ b/internal/waf/waf_test.go
@@ -1,0 +1,125 @@
+package waf
+
+import (
+	"database/sql"
+	"net/http/httptest"
+	"testing"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+// setuptestDB creates an in-memory SQLite database and seeds it with mock rules for testing.
+func setupTestDB(t *testing.T) *sql.DB {
+	db, err := sql.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Fatalf("Failed to open in-memory db: %v", err)
+	}
+
+	// Create the WAF rules table schema
+	_, err = db.Exec(`CREATE TABLE waf_rules (
+		id INTEGER PRIMARY KEY AUTOINCREMENT,
+		name TEXT NOT NULL,
+		expression TEXT NOT NULL,
+		action TEXT NOT NULL DEFAULT 'BLOCK',
+		priority INTEGER DEFAULT 0
+	);`)
+	if err != nil {
+		t.Fatalf("Failed to create waf_rules table: %v", err)
+	}
+
+	// Seed test rules.
+	// Note: We use \s (whitespace) here to prove that the URL decoding in waf.go
+	// successfully translates %20 into real spaces before the regex runs
+	rules := []struct {
+		Name       string
+		Expression string
+	}{
+		{"Block SQLi Query", `RawQuery matches ".*(?i)(union\\s+select|1=1).*"`},
+		{"Block SSRF", `RawQuery matches ".*(?i)(169\\.254\\.169\\.254).*"`},
+		{"Block Admin Path", `Path startsWith "/admin"`},
+	}
+
+	for _, rule := range rules {
+		_, err = db.Exec(`INSERT INTO waf_rules (name, expression, action, priority) VALUES (?, ?, 'BLOCK', 10)`, rule.Name, rule.Expression)
+		if err != nil {
+			t.Fatalf("Failed to insert rule %s: %v", rule.Name, err)
+		}
+	}
+
+	return db
+}
+
+func TestWAFCheck(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+
+	// Table driven test cases
+	tests := []struct {
+		name          string
+		method        string
+		targetURL     string
+		expectBlocked bool
+		expectedRule  string
+	}{
+		{
+			name:          "Safe Request - Root",
+			method:        "GET",
+			targetURL:     "/",
+			expectBlocked: false,
+			expectedRule:  "",
+		},
+		{
+			name:          "Safe Request - Normal Query",
+			method:        "GET",
+			targetURL:     "/products?id=123&sort=asc",
+			expectBlocked: false,
+			expectedRule:  "",
+		},
+		{
+			name:          "Blocked - Admin Path",
+			method:        "GET",
+			targetURL:     "/admin/dashboard",
+			expectBlocked: true,
+			expectedRule:  "Block Admin Path",
+		},
+		{
+			name:          "Blocked - SSRF Attempt",
+			method:        "GET",
+			targetURL:     "/fetch?url=http://169.254.169.254/metadata",
+			expectBlocked: true,
+			expectedRule:  "Block SSRF",
+		},
+		{
+			name:          "Blocked - SQLi with URL Encoded Spaces (%20)",
+			method:        "GET",
+			targetURL:     "/?id=1%20UNION%20SELECT%20password",
+			expectBlocked: true,
+			expectedRule:  "Block SQLi Query",
+		},
+		{
+			name:          "Blocked - SQLi with URL Encoded Spaces (+)",
+			method:        "GET",
+			targetURL:     "/?id=1+UNION+SELECT+password",
+			expectBlocked: true,
+			expectedRule:  "Block SQLi Query",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// mock HTTP request
+			req := httptest.NewRequest(tc.method, tc.targetURL, nil)
+
+			// Run the WAF check
+			blocked, ruleName := Check(db, req, false)
+
+			if blocked != tc.expectBlocked {
+				t.Errorf("Expected blocked: %v, got: %v", tc.expectBlocked, blocked)
+			}
+
+			if tc.expectBlocked && ruleName != tc.expectedRule {
+				t.Errorf("Expected rule triggered: %s, got: %s", tc.expectedRule, ruleName)
+			}
+		})
+	}
+}

--- a/internal/waf/waf_test.go
+++ b/internal/waf/waf_test.go
@@ -14,6 +14,8 @@ func setupTestDB(t *testing.T) *sql.DB {
 	if err != nil {
 		t.Fatalf("Failed to open in-memory db: %v", err)
 	}
+	db.SetMaxOpenConns(1)
+	
 
 	// Create the WAF rules table schema
 	_, err = db.Exec(`CREATE TABLE waf_rules (


### PR DESCRIPTION
Summary

Expanded the WAF to detect common OWASP Top 10 vulnerabilities and patched an encoding bypass bug. The engine previously evaluated r.URL.RawQuery directly, allowing attackers to slip past space-checking rules (like union\s+select) by using %20 or +. Running url.QueryUnescape() on the query data before validation fixes this evasion method.

Changes
internal/waf/waf.go: Added Query and RawQuery to WAFContext and implemented URL-decoding logic.

internal/database/database.go: Seeded default rules targeting SQLi, XSS, Path Traversal, and SSRF.

internal/waf/waf_test.go: Created a new table-driven test suite using an in-memory database to verify blocks on encoded payloads.

Run unit tests with:
go test -v ./internal/waf/...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded web application firewall coverage with additional request-pattern detection across paths and query strings, including stronger SQL injection, XSS, path traversal, and SSRF/localhost-related checks.
  * Improved request inspection by evaluating both parsed and decoded query content for more accurate blocking.

* **Bug Fixes**
  * Now blocks requests when query decoding fails, instead of continuing with incomplete input.
  * Refined rule initialization wording for clearer firewall behavior.

* **Tests**
  * Added automated WAF checks covering safe vs blocked requests, including URL-decoding cases for both `%20` and `+`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->