### PR TITLE
fix(waf): resolve path traversal bypasses in default rules

### DIFF
--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -157,8 +157,7 @@ func seedDefaults(db *sql.DB) error {
 			
 			// OWASP A01:2021 - Broken Access Control (Path Traversal)
 			{"Block Path Traversal", `Path matches "(?:\\.\\./|\\.\\.\\\\)"`, 20},
-			{"Block Path Traversal (Path)", `Path matches ".*(?i)(%2e%2e%2f|%2e%2e\\%5c).*$"`, 20},
-			{"Block Path Traversal (Query)", `RawQuery matches ".*(?i)(%2e%2e%2f|%2e%2e%5c).*$"`, 20},
+			{"Block Path Traversal (Query)", `RawQuery matches "(?:\\.\\./|\\.\\.\\\\)"`, 20},
 			
 			// OWASP A10:2021 - Server-Side Request Forgery (SSRF)
 			{"Block SSRF Metadata & Localhost", `RawQuery matches "(?i)(169\\.254\\.169\\.254|127\\.0\\.0\\.1|localhost)"`, 20},


### PR DESCRIPTION
Update "Block Path Traversal (Query)" to match against URL-decoded patterns `../` and `..\` since `env.RawQuery` is normalized before being passed to the WAF engine.

Remove redundant and broken "Block Path Traversal (Path)" rule, as the base "Block Path Traversal" rule already handles decoded path checks correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated default protection rules for path traversal detection to better handle raw traversal patterns in query strings.
  * Removed an overly specific traversal rule so the app uses a simpler, more consistent check.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->