### PR TITLE
feat(database): add automatic SQLite standby failover

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,8 @@ ai/*.h5
 # Config snapshots
 database/config-snapshot.json
 database/proxy.db
+database/proxy.standby.db
+database/*.corrupt.*
 
 # Compiled binaries
 agent

--- a/config.yml
+++ b/config.yml
@@ -103,6 +103,14 @@ koda_2:
 #   users with the cached configuration
 # - Connection attempts are retried with exponential backoff
 # - All route, WAF, and user configurations remain functional during outages
+# - SQLite primary is mirrored to a hot standby; corrupt primary auto-promotes standby
+# - If both DB copies fail, primary is recreated and rehydrated from the config snapshot
+
+# Local SQLite persistence / automatic data failover
+database:
+  path: "./database/proxy.db"
+  standby_path: "./database/proxy.standby.db"
+  backup_interval_seconds: 300  # 0 disables periodic backups (still backs up after config apply)
 
 routes:
   localhost:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,6 +2,8 @@ package config
 
 import (
 	"os"
+	"path/filepath"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 )
@@ -104,6 +106,13 @@ type Config struct {
 		TimeoutSeconds  int    `yaml:"timeout_seconds"`
 		Path            string `yaml:"path"`
 	} `yaml:"health"`
+
+	// Local SQLite persistence and automatic data failover.
+	Database struct {
+		Path                  string `yaml:"path"`
+		StandbyPath           string `yaml:"standby_path"`
+		BackupIntervalSeconds int    `yaml:"backup_interval_seconds"`
+	} `yaml:"database"`
 }
 
 // HealthChecksEnabled reports whether upstream health probes should run.
@@ -113,6 +122,37 @@ func (c *Config) HealthChecksEnabled() bool {
 		return true
 	}
 	return *c.Health.Enabled
+}
+
+// DatabasePath returns the primary SQLite path (default ./database/proxy.db).
+func (c *Config) DatabasePath() string {
+	if c != nil && strings.TrimSpace(c.Database.Path) != "" {
+		return c.Database.Path
+	}
+	return "./database/proxy.db"
+}
+
+// DatabaseStandbyPath returns the hot-standby SQLite path.
+// Defaults to <primary without extension>.standby.db.
+func (c *Config) DatabaseStandbyPath() string {
+	if c != nil && strings.TrimSpace(c.Database.StandbyPath) != "" {
+		return c.Database.StandbyPath
+	}
+	primary := c.DatabasePath()
+	ext := filepath.Ext(primary)
+	if ext == "" {
+		return primary + ".standby.db"
+	}
+	return strings.TrimSuffix(primary, ext) + ".standby" + ext
+}
+
+// DatabaseBackupIntervalSeconds returns how often to refresh the standby copy.
+// Zero means periodic backups are disabled (snapshot-triggered backups still run).
+func (c *Config) DatabaseBackupIntervalSeconds() int {
+	if c == nil || c.Database.BackupIntervalSeconds <= 0 {
+		return 0
+	}
+	return c.Database.BackupIntervalSeconds
 }
 
 func Load(path string) (*Config, error) {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -576,3 +576,30 @@ custom_error_page: "/path/with spaces/error.html"
 		t.Errorf("CustomErrorPage not preserved correctly")
 	}
 }
+
+func TestDatabasePathDefaults(t *testing.T) {
+	var nilCfg *Config
+	if got := nilCfg.DatabasePath(); got != "./database/proxy.db" {
+		t.Fatalf("nil DatabasePath = %s", got)
+	}
+	if got := nilCfg.DatabaseStandbyPath(); got != "./database/proxy.standby.db" {
+		t.Fatalf("nil DatabaseStandbyPath = %s", got)
+	}
+
+	cfg := &Config{}
+	cfg.Database.Path = "./data/custom.db"
+	if got := cfg.DatabaseStandbyPath(); got != "./data/custom.standby.db" {
+		t.Fatalf("DatabaseStandbyPath = %s, want ./data/custom.standby.db", got)
+	}
+	cfg.Database.StandbyPath = "./data/hot.db"
+	if got := cfg.DatabaseStandbyPath(); got != "./data/hot.db" {
+		t.Fatalf("DatabaseStandbyPath = %s, want ./data/hot.db", got)
+	}
+	if got := cfg.DatabaseBackupIntervalSeconds(); got != 0 {
+		t.Fatalf("BackupInterval default = %d, want 0", got)
+	}
+	cfg.Database.BackupIntervalSeconds = 300
+	if got := cfg.DatabaseBackupIntervalSeconds(); got != 300 {
+		t.Fatalf("BackupInterval = %d, want 300", got)
+	}
+}

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -178,9 +178,27 @@ func copyFile(src, dst string) (err error) {
 		_ = os.Remove(tmp)
 		return err
 	}
-	if err := os.Rename(tmp, dst); err != nil {
+	if err := replaceFile(tmp, dst); err != nil {
 		_ = os.Remove(tmp)
 		return err
+	}
+	return nil
+}
+
+// replaceFile moves src onto dest, replacing dest if it already exists.
+// Plain os.Rename cannot overwrite on Windows, which would break periodic backups.
+func replaceFile(src, dest string) error {
+	if err := os.Rename(src, dest); err == nil {
+		return nil
+	} else if _, statErr := os.Stat(dest); statErr != nil {
+		// Dest does not exist (or is unreadable); surface the original rename error.
+		return err
+	}
+	if err := os.Remove(dest); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("remove existing dest: %w", err)
+	}
+	if err := os.Rename(src, dest); err != nil {
+		return fmt.Errorf("replace after remove: %w", err)
 	}
 	return nil
 }
@@ -208,7 +226,7 @@ func BackupTo(db *sql.DB, destPath string) error {
 		_ = os.Remove(tmp)
 		return fmt.Errorf("vacuum into standby: %w", err)
 	}
-	if err := os.Rename(tmp, destPath); err != nil {
+	if err := replaceFile(tmp, destPath); err != nil {
 		_ = os.Remove(tmp)
 		return err
 	}

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -153,14 +153,18 @@ func removeDBFiles(path string) error {
 	return firstErr
 }
 
-func copyFile(src, dst string) error {
+func copyFile(src, dst string) (err error) {
 	in, err := os.Open(src)
 	if err != nil {
 		return err
 	}
-	defer in.Close()
+	defer func() {
+		if cerr := in.Close(); err == nil && cerr != nil {
+			err = cerr
+		}
+	}()
 
-	tmp := dst + ".promote.tmp"
+	tmp := fmt.Sprintf("%s.promote.%d.tmp", dst, time.Now().UnixNano())
 	out, err := os.OpenFile(tmp, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
 	if err != nil {
 		return err
@@ -182,6 +186,7 @@ func copyFile(src, dst string) error {
 }
 
 // BackupTo writes a consistent copy of db to destPath using an atomic temp+rename.
+// Callers that may run concurrently for the same destPath must serialize externally.
 func BackupTo(db *sql.DB, destPath string) error {
 	if db == nil {
 		return fmt.Errorf("nil database")
@@ -196,8 +201,8 @@ func BackupTo(db *sql.DB, destPath string) error {
 	// Best-effort checkpoint so on-disk WAL state is tidy; VACUUM INTO is still consistent.
 	_, _ = db.Exec(`PRAGMA wal_checkpoint(TRUNCATE)`)
 
-	tmp := destPath + ".tmp"
-	_ = os.Remove(tmp)
+	// Unique staging path avoids collisions if multiple BackupTo calls overlap.
+	tmp := filepath.Join(filepath.Dir(destPath), fmt.Sprintf(".%s.%d.tmp", filepath.Base(destPath), time.Now().UnixNano()))
 	quoted := strings.ReplaceAll(tmp, "'", "''")
 	if _, err := db.Exec(fmt.Sprintf(`VACUUM INTO '%s'`, quoted)); err != nil {
 		_ = os.Remove(tmp)

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -2,8 +2,13 @@ package database
 
 import (
 	"database/sql"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
+	"time"
 
 	_ "github.com/mattn/go-sqlite3"
 	"github.com/rs/zerolog/log"
@@ -16,11 +21,193 @@ func Init(path string) (*sql.DB, error) {
 		return nil, err
 	}
 
-	if err := createTables(db); err != nil {
+	if err := configureDB(db, path); err != nil {
+		_ = db.Close()
 		return nil, err
 	}
 
+	if err := createTables(db); err != nil {
+		_ = db.Close()
+		return nil, err
+	}
+
+	if !isMemoryPath(path) {
+		if err := validateIntegrity(db); err != nil {
+			_ = db.Close()
+			return nil, err
+		}
+	}
+
 	return db, nil
+}
+
+func isMemoryPath(path string) bool {
+	return path == ":memory:" || strings.Contains(path, "mode=memory")
+}
+
+func configureDB(db *sql.DB, path string) error {
+	if isMemoryPath(path) {
+		_, err := db.Exec(`PRAGMA foreign_keys=ON`)
+		return err
+	}
+	if _, err := db.Exec(`PRAGMA journal_mode=WAL`); err != nil {
+		return fmt.Errorf("enable WAL: %w", err)
+	}
+	if _, err := db.Exec(`PRAGMA busy_timeout=5000`); err != nil {
+		return fmt.Errorf("set busy_timeout: %w", err)
+	}
+	if _, err := db.Exec(`PRAGMA foreign_keys=ON`); err != nil {
+		return fmt.Errorf("enable foreign_keys: %w", err)
+	}
+	return nil
+}
+
+func validateIntegrity(db *sql.DB) error {
+	var result string
+	if err := db.QueryRow(`PRAGMA integrity_check`).Scan(&result); err != nil {
+		return fmt.Errorf("integrity_check: %w", err)
+	}
+	if !strings.EqualFold(result, "ok") {
+		return fmt.Errorf("integrity_check failed: %s", result)
+	}
+	return nil
+}
+
+// OpenWithFailover opens the primary database. If that fails, it promotes the
+// standby copy to primary. If both are unusable, it recreates an empty primary
+// so callers can rehydrate from the config snapshot.
+func OpenWithFailover(primary, standby string) (*sql.DB, bool, error) {
+	db, err := Init(primary)
+	if err == nil {
+		return db, false, nil
+	}
+	log.Warn().Err(err).Str("path", primary).Msg("Primary database open failed; attempting standby failover")
+
+	if standby != "" {
+		if _, statErr := os.Stat(standby); statErr == nil {
+			if promoteErr := promoteStandby(standby, primary); promoteErr != nil {
+				log.Warn().Err(promoteErr).Str("standby", standby).Msg("Failed to promote standby database")
+			} else if db, err = Init(primary); err == nil {
+				log.Info().Str("primary", primary).Str("standby", standby).Msg("Promoted standby database to primary")
+				return db, true, nil
+			} else {
+				log.Warn().Err(err).Msg("Promoted standby database is still unusable")
+			}
+		} else {
+			log.Warn().Err(statErr).Str("standby", standby).Msg("Standby database unavailable")
+		}
+	}
+
+	if err := removeDBFiles(primary); err != nil {
+		log.Warn().Err(err).Str("path", primary).Msg("Failed to remove corrupt primary before recreate")
+	}
+	db, err = Init(primary)
+	if err != nil {
+		return nil, false, err
+	}
+	log.Warn().Str("path", primary).Msg("Recreated empty primary database; apply config snapshot to rehydrate")
+	return db, false, nil
+}
+
+func promoteStandby(standby, primary string) error {
+	if err := os.MkdirAll(filepath.Dir(primary), 0755); err != nil {
+		return err
+	}
+	if err := quarantineFile(primary); err != nil {
+		return fmt.Errorf("quarantine primary: %w", err)
+	}
+	_ = os.Remove(primary + "-wal")
+	_ = os.Remove(primary + "-shm")
+	if err := copyFile(standby, primary); err != nil {
+		return fmt.Errorf("copy standby to primary: %w", err)
+	}
+	return nil
+}
+
+func quarantineFile(path string) error {
+	if _, err := os.Stat(path); err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	quarantine := fmt.Sprintf("%s.corrupt.%d", path, time.Now().Unix())
+	if err := os.Rename(path, quarantine); err != nil {
+		if remErr := os.Remove(path); remErr != nil {
+			return err
+		}
+		log.Warn().Str("path", path).Msg("Removed corrupt primary database after quarantine rename failed")
+		return nil
+	}
+	log.Warn().Str("quarantine", quarantine).Msg("Quarantined corrupt primary database")
+	return nil
+}
+
+func removeDBFiles(path string) error {
+	var firstErr error
+	for _, p := range []string{path, path + "-wal", path + "-shm"} {
+		if err := os.Remove(p); err != nil && !os.IsNotExist(err) && firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
+}
+
+func copyFile(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+
+	tmp := dst + ".promote.tmp"
+	out, err := os.OpenFile(tmp, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
+	if err != nil {
+		return err
+	}
+	if _, err := io.Copy(out, in); err != nil {
+		_ = out.Close()
+		_ = os.Remove(tmp)
+		return err
+	}
+	if err := out.Close(); err != nil {
+		_ = os.Remove(tmp)
+		return err
+	}
+	if err := os.Rename(tmp, dst); err != nil {
+		_ = os.Remove(tmp)
+		return err
+	}
+	return nil
+}
+
+// BackupTo writes a consistent copy of db to destPath using an atomic temp+rename.
+func BackupTo(db *sql.DB, destPath string) error {
+	if db == nil {
+		return fmt.Errorf("nil database")
+	}
+	if destPath == "" {
+		return fmt.Errorf("empty standby path")
+	}
+	if err := os.MkdirAll(filepath.Dir(destPath), 0755); err != nil {
+		return err
+	}
+
+	// Best-effort checkpoint so on-disk WAL state is tidy; VACUUM INTO is still consistent.
+	_, _ = db.Exec(`PRAGMA wal_checkpoint(TRUNCATE)`)
+
+	tmp := destPath + ".tmp"
+	_ = os.Remove(tmp)
+	quoted := strings.ReplaceAll(tmp, "'", "''")
+	if _, err := db.Exec(fmt.Sprintf(`VACUUM INTO '%s'`, quoted)); err != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("vacuum into standby: %w", err)
+	}
+	if err := os.Rename(tmp, destPath); err != nil {
+		_ = os.Remove(tmp)
+		return err
+	}
+	return nil
 }
 
 func createTables(db *sql.DB) error {

--- a/internal/database/database_test.go
+++ b/internal/database/database_test.go
@@ -179,3 +179,62 @@ func TestBackupToCreatesOpenableCopy(t *testing.T) {
 		t.Fatalf("target = %s, want http://backup-target", got)
 	}
 }
+
+func TestBackupToOverwritesExistingStandby(t *testing.T) {
+	dir := t.TempDir()
+	primary := filepath.Join(dir, "proxy.db")
+	standby := filepath.Join(dir, "proxy.standby.db")
+
+	db, err := Init(primary)
+	if err != nil {
+		t.Fatalf("Init failed: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	if err := BackupTo(db, standby); err != nil {
+		t.Fatalf("first BackupTo failed: %v", err)
+	}
+	insertRoute(t, db, "domain", "second.example.test", "http://second-target")
+	if err := BackupTo(db, standby); err != nil {
+		t.Fatalf("second BackupTo (overwrite) failed: %v", err)
+	}
+
+	standbyDB, err := Init(standby)
+	if err != nil {
+		t.Fatalf("Init standby failed: %v", err)
+	}
+	t.Cleanup(func() { _ = standbyDB.Close() })
+
+	match, err := GetRouteTargets(standbyDB, "second.example.test", "/")
+	if err != nil {
+		t.Fatalf("GetRouteTargets failed: %v", err)
+	}
+	if got := match.Targets[0].URL; got != "http://second-target" {
+		t.Fatalf("target = %s, want http://second-target", got)
+	}
+}
+
+func TestReplaceFileOverwritesExisting(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src.txt")
+	dst := filepath.Join(dir, "dst.txt")
+	if err := os.WriteFile(src, []byte("new"), 0644); err != nil {
+		t.Fatalf("write src: %v", err)
+	}
+	if err := os.WriteFile(dst, []byte("old"), 0644); err != nil {
+		t.Fatalf("write dst: %v", err)
+	}
+	if err := replaceFile(src, dst); err != nil {
+		t.Fatalf("replaceFile failed: %v", err)
+	}
+	got, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatalf("read dst: %v", err)
+	}
+	if string(got) != "new" {
+		t.Fatalf("dst = %q, want %q", got, "new")
+	}
+	if _, err := os.Stat(src); !os.IsNotExist(err) {
+		t.Fatalf("src should be gone after rename, stat err = %v", err)
+	}
+}

--- a/internal/database/database_test.go
+++ b/internal/database/database_test.go
@@ -2,6 +2,8 @@ package database
 
 import (
 	"database/sql"
+	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -75,5 +77,105 @@ func TestGetRouteTargetsRegexDomain(t *testing.T) {
 	}
 	if got := match.Targets[0].URL; got != "http://regex" {
 		t.Fatalf("target = %s, want http://regex", got)
+	}
+}
+
+func TestBackupToAndOpenWithFailoverPromotesStandby(t *testing.T) {
+	dir := t.TempDir()
+	primary := filepath.Join(dir, "proxy.db")
+	standby := filepath.Join(dir, "proxy.standby.db")
+
+	db, err := Init(primary)
+	if err != nil {
+		t.Fatalf("Init primary failed: %v", err)
+	}
+	insertRoute(t, db, "domain", "failover.example.test", "http://failover-target")
+	if err := BackupTo(db, standby); err != nil {
+		t.Fatalf("BackupTo failed: %v", err)
+	}
+	_ = db.Close()
+
+	if err := os.WriteFile(primary, []byte("this is not a sqlite database"), 0644); err != nil {
+		t.Fatalf("corrupt primary: %v", err)
+	}
+	_ = os.Remove(primary + "-wal")
+	_ = os.Remove(primary + "-shm")
+
+	recoveredDB, recovered, err := OpenWithFailover(primary, standby)
+	if err != nil {
+		t.Fatalf("OpenWithFailover failed: %v", err)
+	}
+	t.Cleanup(func() { _ = recoveredDB.Close() })
+	if !recovered {
+		t.Fatal("expected recovered=true after promoting standby")
+	}
+
+	match, err := GetRouteTargets(recoveredDB, "failover.example.test", "/")
+	if err != nil {
+		t.Fatalf("GetRouteTargets failed: %v", err)
+	}
+	if got := match.Targets[0].URL; got != "http://failover-target" {
+		t.Fatalf("target = %s, want http://failover-target", got)
+	}
+}
+
+func TestOpenWithFailoverRecreatesWhenPrimaryAndStandbyUnusable(t *testing.T) {
+	dir := t.TempDir()
+	primary := filepath.Join(dir, "proxy.db")
+	standby := filepath.Join(dir, "proxy.standby.db")
+
+	if err := os.WriteFile(primary, []byte("corrupt-primary"), 0644); err != nil {
+		t.Fatalf("write primary: %v", err)
+	}
+	if err := os.WriteFile(standby, []byte("corrupt-standby"), 0644); err != nil {
+		t.Fatalf("write standby: %v", err)
+	}
+
+	db, recovered, err := OpenWithFailover(primary, standby)
+	if err != nil {
+		t.Fatalf("OpenWithFailover failed: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if recovered {
+		t.Fatal("expected recovered=false when recreating empty primary")
+	}
+
+	var count int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM routes`).Scan(&count); err != nil {
+		t.Fatalf("query routes: %v", err)
+	}
+	if count == 0 {
+		t.Fatal("recreated database should include seeded defaults")
+	}
+}
+
+func TestBackupToCreatesOpenableCopy(t *testing.T) {
+	dir := t.TempDir()
+	primary := filepath.Join(dir, "proxy.db")
+	standby := filepath.Join(dir, "proxy.standby.db")
+
+	db, err := Init(primary)
+	if err != nil {
+		t.Fatalf("Init failed: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	insertRoute(t, db, "domain", "backup.example.test", "http://backup-target")
+
+	if err := BackupTo(db, standby); err != nil {
+		t.Fatalf("BackupTo failed: %v", err)
+	}
+
+	standbyDB, err := Init(standby)
+	if err != nil {
+		t.Fatalf("Init standby failed: %v", err)
+	}
+	t.Cleanup(func() { _ = standbyDB.Close() })
+
+	match, err := GetRouteTargets(standbyDB, "backup.example.test", "/")
+	if err != nil {
+		t.Fatalf("GetRouteTargets failed: %v", err)
+	}
+	if got := match.Targets[0].URL; got != "http://backup-target" {
+		t.Fatalf("target = %s, want http://backup-target", got)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -15,6 +15,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/rs/zerolog"
@@ -1276,10 +1277,17 @@ func applyConfigUpdates(db *sql.DB, mgr *streaming.Manager, healthWorker *health
 	}
 }
 
+// databaseStandbyMu serializes refreshDatabaseStandby so config-update and
+// periodic backup goroutines cannot race on the same standby staging files.
+var databaseStandbyMu sync.Mutex
+
 func refreshDatabaseStandby(db *sql.DB, standbyPath string) {
 	if standbyPath == "" {
 		return
 	}
+	databaseStandbyMu.Lock()
+	defer databaseStandbyMu.Unlock()
+
 	if err := database.BackupTo(db, standbyPath); err != nil {
 		log.Warn().Err(err).Str("path", standbyPath).Msg("Failed to update database standby")
 		return

--- a/main.go
+++ b/main.go
@@ -56,23 +56,35 @@ func main() {
 		log.Info().Bool("debug_logs", cfg.DebugLogs).Bool("honeypot", cfg.Honeypot).Bool("auth_enabled", cfg.Auth.Enabled).Msg("Loaded configuration")
 	}
 
-	if err := os.MkdirAll("./database", 0755); err != nil {
+	dbPath := cfg.DatabasePath()
+	standbyPath := cfg.DatabaseStandbyPath()
+	if err := os.MkdirAll(filepath.Dir(dbPath), 0755); err != nil {
 		log.Fatal().Err(err).Msg("Failed to create database directory")
 	}
 
-	db, err := database.Init("./database/proxy.db")
+	db, recovered, err := database.OpenWithFailover(dbPath, standbyPath)
 	if err != nil {
 		log.Fatal().Err(err).Msg("Failed to initialize database")
 	}
 	defer db.Close()
+	if recovered {
+		log.Info().Str("primary", dbPath).Str("standby", standbyPath).Msg("Database recovered from standby")
+	}
 
-	streamMgr := streaming.NewManager("./database/config-snapshot.json")
+	snapshotPath := filepath.Join(filepath.Dir(dbPath), "config-snapshot.json")
+	streamMgr := streaming.NewManager(snapshotPath)
 	defer streamMgr.Close()
 
 	log.Info().Msg("Applying initial configuration from snapshot")
 	initialSnap := streamMgr.GetSnapshot()
 	applySnapshotToDB(db, initialSnap)
+	refreshDatabaseStandby(db, standbyPath)
 	applyAgentConfigToConfig(cfg, initialSnap.AgentConfig)
+
+	if backupEvery := cfg.DatabaseBackupIntervalSeconds(); backupEvery > 0 {
+		startDatabaseBackupLoop(db, standbyPath, time.Duration(backupEvery)*time.Second)
+		log.Info().Int("interval_seconds", backupEvery).Str("standby", standbyPath).Msg("Periodic database standby backups enabled")
+	}
 
 	healthInterval := time.Duration(ifZeroInt(cfg.Health.IntervalSeconds, 10)) * time.Second
 	healthTimeout := time.Duration(ifZeroInt(cfg.Health.TimeoutSeconds, 3)) * time.Second
@@ -113,7 +125,7 @@ func main() {
 		log.Info().Msg("No API_STREAM_URL configured, running in offline mode with local configuration")
 	}
 
-	go applyConfigUpdates(db, streamMgr, healthWorker, healthChecksEnabled)
+	go applyConfigUpdates(db, streamMgr, healthWorker, healthChecksEnabled, standbyPath)
 
 	pages := buildErrorPageStore(cfg)
 
@@ -1247,7 +1259,7 @@ func applyAgentConfigToConfig(cfg *config.Config, agentConfig streaming.AgentCon
 }
 
 // applyConfigUpdates subscribes to config changes and applies them to the database.
-func applyConfigUpdates(db *sql.DB, mgr *streaming.Manager, healthWorker *health.Worker, healthChecksEnabled bool) {
+func applyConfigUpdates(db *sql.DB, mgr *streaming.Manager, healthWorker *health.Worker, healthChecksEnabled bool, standbyPath string) {
 	ch := mgr.Subscribe()
 	log.Info().Msg("Config update subscriber started")
 
@@ -1257,10 +1269,35 @@ func applyConfigUpdates(db *sql.DB, mgr *streaming.Manager, healthWorker *health
 			continue
 		}
 		applySnapshotToDB(db, snap)
+		refreshDatabaseStandby(db, standbyPath)
 		if healthChecksEnabled {
 			syncHealthTargets(db, healthWorker)
 		}
 	}
+}
+
+func refreshDatabaseStandby(db *sql.DB, standbyPath string) {
+	if standbyPath == "" {
+		return
+	}
+	if err := database.BackupTo(db, standbyPath); err != nil {
+		log.Warn().Err(err).Str("path", standbyPath).Msg("Failed to update database standby")
+		return
+	}
+	log.Debug().Str("path", standbyPath).Msg("Database standby updated")
+}
+
+func startDatabaseBackupLoop(db *sql.DB, standbyPath string, interval time.Duration) {
+	if db == nil || standbyPath == "" || interval <= 0 {
+		return
+	}
+	go func() {
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for range ticker.C {
+			refreshDatabaseStandby(db, standbyPath)
+		}
+	}()
 }
 
 func syncHealthTargets(db *sql.DB, worker *health.Worker) {

--- a/main.go
+++ b/main.go
@@ -62,6 +62,12 @@ func main() {
 	if err := os.MkdirAll(filepath.Dir(dbPath), 0755); err != nil {
 		log.Fatal().Err(err).Msg("Failed to create database directory")
 	}
+	// Keep the historical snapshot location stable so custom database.path values
+	// do not orphan an existing ./database/config-snapshot.json.
+	const snapshotPath = "./database/config-snapshot.json"
+	if err := os.MkdirAll(filepath.Dir(snapshotPath), 0755); err != nil {
+		log.Fatal().Err(err).Msg("Failed to create config snapshot directory")
+	}
 
 	db, recovered, err := database.OpenWithFailover(dbPath, standbyPath)
 	if err != nil {
@@ -72,7 +78,6 @@ func main() {
 		log.Info().Str("primary", dbPath).Str("standby", standbyPath).Msg("Database recovered from standby")
 	}
 
-	snapshotPath := filepath.Join(filepath.Dir(dbPath), "config-snapshot.json")
 	streamMgr := streaming.NewManager(snapshotPath)
 	defer streamMgr.Close()
 


### PR DESCRIPTION
## Summary
- Add WAL-backed SQLite open with integrity checks and hot-standby backups
- Auto-promote standby when primary is corrupt; recreate + rehydrate from config snapshot if both fail
- Wire configurable `database.path` / `standby_path` / `backup_interval_seconds` (closes #101)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable local database persistence with primary and standby locations.
  * Added automatic database failover: if the primary is corrupted/unavailable, the standby is promoted and the service continues.
  * Added periodic standby refresh backups with atomic overwrite to keep the standby copy current.
* **Bug Fixes**
  * Improved SQLite reliability for on-disk databases with durability/integrity checks; when failover can’t recover data, a fresh usable primary is recreated with default content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->